### PR TITLE
close 17 - move mouse combo

### DIFF
--- a/config/combos.dtsi
+++ b/config/combos.dtsi
@@ -27,7 +27,6 @@
 /* Horizontal combos - left hand */
 ZMK_COMBO(esc,   &kp ESC,       LT3 LT2,     DEF NAV NUM, COMBO_TERM_FAST)
 ZMK_COMBO(repeat,HRC_REPEAT,    LT2 LT1,     DEF NAV NUM, COMBO_TERM_FAST)
-ZMK_COMBO(mouse, &smart_mouse,  LT3 LT1,     DEF NAV NUM, COMBO_TERM_SLOW)
 
 ZMK_COMBO(tab,   HRC_TAB,       LM3 LM2,     DEF NAV NUM, COMBO_TERM_FAST)
 ZMK_COMBO(ret,   HRC_RETURN,    LM2 LM1,     DEF NAV NUM, COMBO_TERM_FAST)
@@ -54,6 +53,9 @@ ZMK_COMBO(rbrc,  &kp RBRC,      RB2 RB3,         NAV    , COMBO_TERM_FAST)
 
 ZMK_COMBO(grk,   &sl UC,        RT1 RT3,     DEF NAV NUM, COMBO_TERM_SLOW)
 ZMK_COMBO(cpgrk, &sls 0,        RT1 RT2 RT3, DEF NAV NUM, COMBO_TERM_SLOW)
+
+/* Horizontal combos - both hands */
+ZMK_COMBO(mouse, &smart_mouse,  LT1 RT1,     DEF NAV NUM, COMBO_TERM_SLOW)
 
 /* Vertical combos - left hand */
 ZMK_COMBO(dqt,   &kp AT,        LT3 LM3,     DEF NAV NUM, COMBO_TERM_SLOW)


### PR DESCRIPTION
Move the combo to activate the mouse layer from `LT1/LT3` to `LT1/RT1`.