### PR TITLE
Remove dot_spc macro fix 29

### DIFF
--- a/config/base.keymap
+++ b/config/base.keymap
@@ -206,15 +206,6 @@ ZMK_BEHAVIOR(lt_spc, hold_tap,
     quick-tap-ms = <QUICK_TAP_MS>;
     bindings = <&mo>, <&kp SPACE>;
 )
-ZMK_BEHAVIOR(spc_morph, mod_morph,
-    bindings = <&kp SPACE>, <&dot_spc>;
-    mods = <(MOD_LSFT|MOD_RSFT)>;
-)
-ZMK_BEHAVIOR(dot_spc, macro,
-    wait-ms = <0>;
-    tap-ms = <5>;
-    bindings = <&kp DOT &kp SPACE &sk LSHFT>;
-)
 
 // tap: qu | hold: q
 ZMK_BEHAVIOR(qu, hold_tap,

--- a/config/base.keymap
+++ b/config/base.keymap
@@ -204,7 +204,7 @@ ZMK_BEHAVIOR(lt_spc, hold_tap,
     flavor = "balanced";
     tapping-term-ms = <200>;
     quick-tap-ms = <QUICK_TAP_MS>;
-    bindings = <&mo>, <&kp SPACE>;
+    bindings = <&mo>, <&kp>;
 )
 
 // tap: qu | hold: q
@@ -270,7 +270,7 @@ ZMK_LAYER(base,
 //├──────┤ ├─────────────┼─────────────┼─────────────┼─────────────┼─────────────┤ ├──────┤ ├─────────────┼─────────────┼─────────────┼─────────────┼─────────────┤ ├──────┤
     X_LB     &qu Q 0       &kp J         &kp V         &kp D         &kp K           X_MB     &kp X         &kp H         &comma_morph  &dot_morph    &qexcl          X_RB
 //├──────┤ ╰─────────────┼─────────────┴─────────────┼─────────────┼─────────────┤ ├──────┤ ├─────────────┼─────────────┼─────────────┴───────────────────────────╯ ├──────┤
-    X_LH                                               &smart_shft   &lt_quot FN 0   X_MH      SMART_NUM    &lt_spc NAV 0                                             X_RH
+    X_LH                                               &smart_shft   &lt_quot FN 0   X_MH      SMART_NUM    &lt_spc NAV SPACE                                         X_RH
 //╰──────╯                                           ╰─────────────┴─────────────╯ ╰──────╯ ╰─────────────┴─────────────╯                                           ╰──────╯
 )
 

--- a/config/base.keymap
+++ b/config/base.keymap
@@ -204,7 +204,7 @@ ZMK_BEHAVIOR(lt_spc, hold_tap,
     flavor = "balanced";
     tapping-term-ms = <200>;
     quick-tap-ms = <QUICK_TAP_MS>;
-    bindings = <&mo>, <&spc_morph>;
+    bindings = <&mo>, <&kp SPACE>;
 )
 ZMK_BEHAVIOR(spc_morph, mod_morph,
     bindings = <&kp SPACE>, <&dot_spc>;


### PR DESCRIPTION
Remove the `spc_morph` macro from the tap behaviour of `lt_spc`.