### PR TITLE
31 remove <>

### DIFF
--- a/config/base.keymap
+++ b/config/base.keymap
@@ -176,11 +176,7 @@ ZMK_BEHAVIOR(quot_morph, mod_morph,
 // tap: comma | shift + tap: semicolon | ctrl + shift + tap: <
 ZMK_BEHAVIOR(comma_morph, mod_morph,
     mods = <(MOD_LSFT|MOD_RSFT)>;
-    bindings = <&kp COMMA>, <&comma_inner_morph>;
-)
-ZMK_BEHAVIOR(comma_inner_morph, mod_morph,
-    bindings = <&kp SEMICOLON>, <&kp LESS_THAN>;
-    mods = <(MOD_LCTL|MOD_RCTL)>;
+    bindings = <&kp COMMA>, <&kp SEMICOLON>;
 )
 
 // tap: dot | shift + tap: colon | ctrl + shift + tap: >

--- a/config/base.keymap
+++ b/config/base.keymap
@@ -181,12 +181,8 @@ ZMK_BEHAVIOR(comma_morph, mod_morph,
 
 // tap: dot | shift + tap: colon | ctrl + shift + tap: >
 ZMK_BEHAVIOR(dot_morph, mod_morph,
-    bindings = <&kp DOT>, <&dot_inner_morph>;
+    bindings = <&kp DOT>, <&kp COLON>;
     mods = <(MOD_LSFT|MOD_RSFT)>;
-)
-ZMK_BEHAVIOR(dot_inner_morph, mod_morph,
-    bindings = <&kp COLON>, <&kp GREATER_THAN>;
-    mods = <(MOD_LCTL|MOD_RCTL)>;
 )
 
 // tap: qmark | shift + tap: excl


### PR DESCRIPTION
Remove `<` and `>` from `ctrl+shift+,` and `.` as they are available elsewhere and these combos are required in VSCode.